### PR TITLE
PEP 545: Include translations in the Governance topic

### DIFF
--- a/peps/pep-0545.rst
+++ b/peps/pep-0545.rst
@@ -5,6 +5,7 @@ Author: Julien Palard <julien@palard.fr>,
         Victor Stinner <vstinner@python.org>
 Status: Final
 Type: Process
+Topic: Governance
 Content-Type: text/x-rst
 Created: 04-Mar-2017
 Resolution: https://mail.python.org/pipermail/python-dev/2017-May/147957.html


### PR DESCRIPTION
PEP 545 covers the governance procedures for the
python.org hosted documentation translations,
it was just written and accepted before the separate topic pages existed.

<!-- readthedocs-preview pep-previews start -->
----
📚 Documentation preview 📚: https://pep-previews--9.org.readthedocs.build/

<!-- readthedocs-preview pep-previews end -->